### PR TITLE
Add istio gateway PodMonitors package

### DIFF
--- a/packages/istio-gateway-metrics/chart/Chart.yaml
+++ b/packages/istio-gateway-metrics/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: istio-gateway-metrics
+description: PodMonitors to scrape Envoy /stats/prometheus from Istio gateways
+type: application
+version: 0.1.0
+appVersion: 0.1.0

--- a/packages/istio-gateway-metrics/chart/templates/_helpers.tpl
+++ b/packages/istio-gateway-metrics/chart/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "istio-gateway-metrics.namespace" -}}
+{{- default "monitoring" .Values.namespace -}}
+{{- end -}}

--- a/packages/istio-gateway-metrics/chart/templates/podmonitors.yaml
+++ b/packages/istio-gateway-metrics/chart/templates/podmonitors.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.podMonitors.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Values.podMonitors.adminGateway.name | quote }}
+  namespace: {{ include "istio-gateway-metrics.namespace" . }}
+  labels:
+    app.kubernetes.io/part-of: istio
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Values.podMonitors.adminGateway.namespace | quote }}
+  selector:
+    matchLabels:
+{{ toYaml .Values.podMonitors.adminGateway.selector | indent 6 }}
+  podMetricsEndpoints:
+    - port: {{ .Values.podMonitors.adminGateway.port | quote }}
+      path: {{ .Values.podMonitors.envoyPath | quote }}
+      interval: {{ .Values.podMonitors.interval | quote }}
+      scrapeTimeout: {{ .Values.podMonitors.scrapeTimeout | quote }}
+      scheme: {{ .Values.podMonitors.scheme | quote }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Values.podMonitors.tenantGateway.name | quote }}
+  namespace: {{ include "istio-gateway-metrics.namespace" . }}
+  labels:
+    app.kubernetes.io/part-of: istio
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Values.podMonitors.tenantGateway.namespace | quote }}
+  selector:
+    matchLabels:
+{{ toYaml .Values.podMonitors.tenantGateway.selector | indent 6 }}
+  podMetricsEndpoints:
+    - port: {{ .Values.podMonitors.tenantGateway.port | quote }}
+      path: {{ .Values.podMonitors.envoyPath | quote }}
+      interval: {{ .Values.podMonitors.interval | quote }}
+      scrapeTimeout: {{ .Values.podMonitors.scrapeTimeout | quote }}
+      scheme: {{ .Values.podMonitors.scheme | quote }}
+{{- end }}

--- a/packages/istio-gateway-metrics/chart/values.yaml
+++ b/packages/istio-gateway-metrics/chart/values.yaml
@@ -1,0 +1,20 @@
+namespace: monitoring
+
+podMonitors:
+  enabled: true
+  interval: 15s
+  scrapeTimeout: 10s
+  scheme: http
+  envoyPath: /stats/prometheus
+  adminGateway:
+    name: admin-gateway-envoy-prom
+    namespace: istio-admin-gateway
+    selector:
+      istio: admin-ingressgateway
+    port: http-envoy-prom
+  tenantGateway:
+    name: tenant-gateway-envoy-prom
+    namespace: istio-tenant-gateway
+    selector:
+      istio: tenant-ingressgateway
+    port: http-envoy-prom

--- a/packages/istio-gateway-metrics/zarf.yaml
+++ b/packages/istio-gateway-metrics/zarf.yaml
@@ -1,0 +1,14 @@
+kind: ZarfPackageConfig
+metadata:
+  name: istio-gateway-metrics
+  description: PodMonitors for admin + tenant istio gateways (Envoy /stats/prometheus)
+  version: 0.1.0
+
+components:
+  - name: istio-gateway-metrics
+    required: true
+    charts:
+      - name: istio-gateway-metrics
+        version: 0.1.0
+        localPath: chart
+        namespace: monitoring

--- a/scripts/test-istio-gateway-metrics-helm.sh
+++ b/scripts/test-istio-gateway-metrics-helm.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CHART_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/packages/istio-gateway-metrics/chart"
+
+if ! command -v helm >/dev/null 2>&1; then
+  echo "helm is required for this test" >&2
+  exit 1
+fi
+
+# Render with PodMonitor CRD available.
+out="$(helm template istio-gateway-metrics "$CHART_DIR" \
+  --api-versions monitoring.coreos.com/v1)"
+
+echo "$out" | grep -q "kind: PodMonitor" 
+echo "$out" | grep -q "name: \"admin-gateway-envoy-prom\""
+echo "$out" | grep -q "name: \"tenant-gateway-envoy-prom\""
+
+# Render without PodMonitor CRD available (should produce no manifests).
+out2="$(helm template istio-gateway-metrics "$CHART_DIR")"
+if echo "$out2" | grep -q "kind: PodMonitor"; then
+  echo "expected no PodMonitor output when CRD is not available" >&2
+  exit 1
+fi
+
+echo "ok"

--- a/tasks/packages.yaml
+++ b/tasks/packages.yaml
@@ -29,3 +29,15 @@ tasks:
       - task: create
         with:
           path: packages/experimental-gateway-crds
+
+  - name: istio-gateway-metrics
+    description: "Local package with PodMonitors for admin + tenant istio gateways"
+    actions:
+      - task: create
+        with:
+          path: packages/istio-gateway-metrics
+
+  - name: test-istio-gateway-metrics-helm
+    description: "Smoke-test Helm templates for istio-gateway-metrics"
+    actions:
+      - cmd: ./scripts/test-istio-gateway-metrics-helm.sh

--- a/uds-bundle.yaml
+++ b/uds-bundle.yaml
@@ -35,3 +35,9 @@ packages:
           variables:
             - name: ALLOW_ALL_NS_EXEMPTIONS
               path: cluster.policy.allowAllNsExemptions
+
+  # Local Zarf package: PodMonitors for scraping Envoy stats from admin+tenant gateways.
+  # Guarded by Helm Capabilities (won't render if PodMonitor CRD isn't present yet).
+  - name: istio-gateway-metrics
+    path: ./packages/istio-gateway-metrics
+    ref: 0.1.0


### PR DESCRIPTION
Implements durable gateway metrics scraping via a local Helm/Zarf package, rather than one-off manifests.

- Adds `packages/istio-gateway-metrics` chart that renders `PodMonitor` resources for admin + tenant gateways when the CRD is present
- Wires the local package into `uds-bundle.yaml`
- Adds a Helm template smoke test (`scripts/test-istio-gateway-metrics-helm.sh`)

Tracking: andygodish/package-monitoring#17
Context: andygodish/package-monitoring#8 (A)
